### PR TITLE
Add note for American users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The plugin expects to get a list of readings in JSON form:
 ```
 You can use [this guide](https://hackernoon.com/how-to-measure-particulate-matter-with-a-raspberry-pi-75faa470ec35) to setup a Python script to read values from a SDS011 sensor to a file.
 
+For American users, make sure to change line 137 (jsonrow) of aqi.py (from the guide above). The date format must be changed from `%d.%m.%Y` to `%m.%d.%Y` for the plugin to work.
+
 ## Installation and configuration
 Run `npm install homebridge-air-quality-file`
 


### PR DESCRIPTION
This took me hours to figure out... The plugin would constantly fail with the error below. The simple change noted in the readme will resolve the issue.

```
Nov 17 17:45:29 raspberrypi homebridge[31046]: [11/17/2020, 17:45:29] TypeError: Cannot read property 'pm25' of undefined
Nov 17 17:45:29 raspberrypi homebridge[31046]:     at /usr/local/lib/node_modules/homebridge-air-quality-file/dist/index.js:174:38
Nov 17 17:45:29 raspberrypi homebridge[31046]:     at /usr/local/lib/node_modules/homebridge-air-quality-file/dist/index.js:68:12
Nov 17 17:45:29 raspberrypi homebridge[31046]:     at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)
```